### PR TITLE
Fix use of wrong signtool parameter for computer vs user store

### DIFF
--- a/Tasks/authenticode-sign/entry.ts
+++ b/Tasks/authenticode-sign/entry.ts
@@ -59,12 +59,12 @@ function pushTimestampArgs(args: string[]) {
 async function pushCertArgs(args: string[]) {
     let certificateLocation: string = tl.getInput("certificateLocation", true);
     if (certificateLocation === "computerStore") {
-        return; // Nothing to do.
+        args.push("/sm");
+        return;
     }
 
     if (certificateLocation === "userStore") {
-        args.push("/sm");
-        return;
+        return; // Nothing to do.
     }
 
     let pfxLocation: string = null;


### PR DESCRIPTION
To use the computer store the `/sm` parameter needs to be passed (see: https://msdn.microsoft.com/en-us/library/windows/desktop/aa387764%28v=vs.85%29.aspx).

Before the `/sm` parameter was passed when the user store was selected for the task.